### PR TITLE
Location Creation Enhancements

### DIFF
--- a/app/components/DescriptionInput/DescriptionInput.js
+++ b/app/components/DescriptionInput/DescriptionInput.js
@@ -16,7 +16,7 @@ export default class DescriptionInput extends Component {
           multiline={true}
           onChangeText={(description) => this.props.onChange(description)}
           value={this.props.description}
-          placeholder='Description'
+          placeholder={this.props.placeholder || ''}
         />
       </View>
     )
@@ -24,6 +24,7 @@ export default class DescriptionInput extends Component {
 }
 
 DescriptionInput.propTypes = {
+  placeholder: PropTypes.string,
   description: PropTypes.string,
   onChange: PropTypes.func
 };

--- a/app/components/LocationCard/LocationCard.js
+++ b/app/components/LocationCard/LocationCard.js
@@ -5,7 +5,6 @@ import MapView from 'react-native-maps';
 import { LocationCardCSS as Css } from './LocationCard.css'
 import LocationIcon from '../Icons/LocationIcon'
 import MoreVertIcon from '../Icons/MoreVertIcon'
-import primaryMarkerImage from '../../assets/primary-marker.png';
 
 export default class LocationCard extends Component {
   render() {
@@ -16,8 +15,9 @@ export default class LocationCard extends Component {
             <LocationIcon size={24}/>
           </View>
           <View style={Css.headerText}>
-            <Text style={Css.title}>{this.props.title}</Text>
-            <Text style={Css.subhead}>{this.props.latitude + ', ' + this.props.longitude}</Text>
+            <Text style={Css.title}>{this.props.title || 'Unnamed Point'}</Text>
+            <Text style={Css.subhead}>{this.props.latitude.toFixed(6) +
+              ', ' + this.props.longitude.toFixed(6)}</Text>
           </View>
           <View style={Css.rightButton}>
             <MoreVertIcon size={24}/>
@@ -39,10 +39,14 @@ export default class LocationCard extends Component {
               latitude: this.props.latitude,
               longitude: this.props.longitude
             }}
-            image={primaryMarkerImage}
           />
         </MapView>
-        <Text style={Css.content}>{this.props.content ? this.props.content : 'no content'}</Text>
+        <Text
+          style={Css.content}
+          ellipsizeMode="tail"
+          numberOfLines={1}
+        >
+          {this.props.content ? this.props.content : 'No content'}</Text>
       </View>
     )
   }

--- a/app/containers/scenes/ChallengeCreationScene.css.js
+++ b/app/containers/scenes/ChallengeCreationScene.css.js
@@ -14,7 +14,7 @@ export const ChallengeCreationCSS = StyleSheet.create({
     fontSize: 16
   },
   footer: {
-    height: 48,
+    height: 56,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',

--- a/app/containers/scenes/ChallengeCreationScene.js
+++ b/app/containers/scenes/ChallengeCreationScene.js
@@ -46,6 +46,7 @@ export default class ChallengeCreationScene extends Component {
           />
           <ListDivider/>
           <DescriptionInput
+            placeholder={'Description'}
             description={this.state.description}
             onChange={(description) => this.setState({ description })}
           />

--- a/app/containers/scenes/LocationCreationScene.css.js
+++ b/app/containers/scenes/LocationCreationScene.css.js
@@ -13,8 +13,11 @@ export const LocationCreationCSS = StyleSheet.create({
     paddingRight: 16,
     fontSize: 16
   },
+	map: {
+		flex: 1,
+	},
   footer: {
-    height: 48,
+    height: 56,
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',

--- a/app/containers/scenes/LocationCreationScene.js
+++ b/app/containers/scenes/LocationCreationScene.js
@@ -25,11 +25,15 @@ export default class LocationCreationScene extends Component {
     } else {
       this.state = {
         title: '',
-        latitude: undefined,
-        longitude: undefined,
+        latitude: 40.248660, // TODO: this defaults to BYU Campus
+        longitude: -111.649194, // TODO: handle this more gracefully
         content: '',
       }
     }
+  }
+
+  componentDidMount() {
+    this.getCurrentPosition();
   }
 
   render() {
@@ -46,10 +50,9 @@ export default class LocationCreationScene extends Component {
         />
         <MapView
           style={Css.map}
-          showsUserLocation={true}
-          initialRegion={this.getMapRegionByLocation() || {
-            latitude: 40.248660, // TODO: this defaults to BYU Campus
-            longitude: -111.649194, // TODO: handle this more gracefully
+          initialRegion={{
+            latitude: this.state.latitude,
+            longitude: this.state.longitude,
             latitudeDelta: LATITUDE_DELTA,
             longitudeDelta: LONGITUDE_DELTA
           }}
@@ -89,17 +92,15 @@ export default class LocationCreationScene extends Component {
     );
   }
 
-  getMapRegionByLocation(){
+  getCurrentPosition(){
 		navigator.geolocation.getCurrentPosition(
 			(position) => {
-				return {
-						latitude: position.coords.latitude,
-						longitude: position.coords.longitude,
-						latitudeDelta: LATITUDE_DELTA,
-						longitudeDelta: LONGITUDE_DELTA
-				};
-			},
-			(error) => undefined,
+        this.setState({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        });
+      },
+			(error) => {}
 		);
   }
 


### PR DESCRIPTION
## Overview
This PR adds a map to the location creation screen. Users can optionally add a title and a message to the location. Tapping the add button will add that point to the challenge. The location defaults to the user's current position.

## Bug Fixes
 - Empty location titles display correctly on the cards
 - Long messages are truncated with ellipsis and maintain correct sizing
 - Footer buttons size has been increased to match the rest of the view
 - Default location is assigned so no `undefined` errors are thrown.